### PR TITLE
Choose a random interval from all lowest intervals found

### DIFF
--- a/src/load_balanced_scheduler.py
+++ b/src/load_balanced_scheduler.py
@@ -8,6 +8,7 @@ import datetime
 from aqt import mw
 from anki.sched import Scheduler
 from anki.schedv2 import Scheduler
+from random import choice
 
 
 def log_info(message):
@@ -24,20 +25,24 @@ def load_balanced_ivl(self, ivl):
     """Return the (largest) interval that has the least number of cards and falls within the 'fuzz'"""
     orig_ivl = int(ivl)
     min_ivl, max_ivl = self._fuzzIvlRange(orig_ivl)
-    min_num_cards = 18446744073709551616        # Maximum number of rows in an sqlite table?
     best_ivl = 1
+    lowest_num_cards_in_range=18446744073709551616
+    acceptable_ivls=[]
     for check_ivl in range(min_ivl, max_ivl + 1):
         num_cards = self.col.db.scalar("""select count() from cards where due = ? and queue = 2""",
                                        self.today + check_ivl)
-        if num_cards <= min_num_cards:
-            best_ivl = check_ivl
-            log_debug("> ")
+        if num_cards < lowest_num_cards_in_range:
+            acceptable_ivls=[check_ivl]
+            lowest_num_cards_in_range=num_cards
+        elif num_cards == lowest_num_cards_in_range:
+            acceptable_ivls.append(check_ivl)
             min_num_cards = num_cards
         else:
-            log_debug("  ")
-        log_debug("check_ivl {0:<4} num_cards {1:<4} best_ivl {2:<4}\n".format(check_ivl, num_cards, best_ivl))
-    log_info("{0:<28} orig_ivl {1:<4} min_ivl {2:<4} max_ivl {3:<4} best_ivl {4:<4}\n"
-             .format(str(datetime.datetime.now()), orig_ivl, min_ivl, max_ivl, best_ivl))
+            log_debug("")
+        log_debug("check_ivl {0:<4} num_cards {1:<4} acceptable_ivls {2}\n".format(check_ivl, num_cards, acceptable_ivls))
+    best_ivl = choice(acceptable_ivls)
+    log_info("{0:<28} orig_ivl {1:<4} min_ivl {2:<4} max_ivl {3:<4} acceptable_ivls {4}\n best_ivl {5:<4}"
+             .format(str(datetime.datetime.now()), orig_ivl, min_ivl, max_ivl, acceptable_ivls, best_ivl))
     return best_ivl
 
 


### PR DESCRIPTION
I noticed that the addon always chooses the latest possible option for best_ivl, which will almost always push scheduling to be later than Anki naturally wants it to be. This, in turn, will increase the rate of wrong answers and ultimately just make reviewing harder than it needs to be.

This proposed change collects the lowest num_cards values for every interval between min_ivl and max_ivl, then stores those values inside a list called acceptable_ivls. It chooses a random item from within that list for best_ivl.

Logging functions were modified rather liberally to accommodate the changes.